### PR TITLE
feat(db): adds db, initalizes movie model, and implements test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,13 @@ language: node_js
 sudo: false
 node_js:
   - 5
+env:
+  - NODE_ENV="test"
+before_script:
+  - createuser sfmovies_user
+  - createdb -O sfmovies_user sfmovies_test
+  - npm run db:migrate
 script:
+  - npm test
+  - npm run enforce
   - npm run lint

--- a/config/development.js
+++ b/config/development.js
@@ -1,5 +1,10 @@
 'use strict';
 
 module.exports = {
-  PORT: 3000
+  PORT: 3000,
+  DB_NAME: 'sfmovies_development',
+  DB_HOST: 'localhost',
+  DB_PORT: 5432,
+  DB_PASSWORD: '',
+  DB_USER: 'sfmovies_user'
 };

--- a/config/test.js
+++ b/config/test.js
@@ -1,5 +1,10 @@
 'use strict';
 
 module.exports = {
-  PORT: 3000
+  PORT: 3000,
+  DB_NAME: 'sfmovies_test',
+  DB_HOST: 'localhost',
+  DB_PORT: 5432,
+  DB_PASSWORD: '',
+  DB_USER: 'sfmovies_user'
 };

--- a/db/index.js
+++ b/db/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const Config = require('../config');
+
+module.exports = {
+  client: 'postgresql',
+  connection: {
+    database: Config.DB_NAME,
+    host: Config.DB_HOST,
+    password: Config.DB_PASSWORD,
+    port: Config.DB_PORT,
+    user: Config.DB_USER
+  }
+};

--- a/db/migrations/.eslintrc
+++ b/db/migrations/.eslintrc
@@ -1,0 +1,3 @@
+{
+  extends: "eslint-config-lob/migrations"
+}

--- a/db/migrations/20160526111037_create_movies.js
+++ b/db/migrations/20160526111037_create_movies.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return knex.schema.createTable('movies', (table) => {
+    table.increments('id').primary();
+    table.string('title', 255).notNullable();
+    table.integer('release_year');
+  });
+};
+
+exports.down = function (knex, Promise) {
+  return knex.schema.dropTable('movies');
+};

--- a/db/seeds/data/movies.json
+++ b/db/seeds/data/movies.json
@@ -1,0 +1,1100 @@
+[{
+  "title": "180",
+  "release_year": 2011
+},
+{
+  "title": "24 Hours on Craigslist",
+  "release_year": 2005
+},
+{
+  "title": "40 Days and 40 Nights",
+  "release_year": 2002
+},
+{
+  "title": "48 Hours",
+  "release_year": 1982
+},
+{
+  "title": "50 First Dates",
+  "release_year": 2004
+},
+{
+  "title": "A Jitney Elopement",
+  "release_year": 1915
+},
+{
+  "title": "A Night Full of Rain",
+  "release_year": 1978
+},
+{
+  "title": "A Smile Like Yours",
+  "release_year": 1997
+},
+{
+  "title": "A View to a Kill",
+  "release_year": 1985
+},
+{
+  "title": "About a Boy",
+  "release_year": 2014
+},
+{
+  "title": "After the Thin Man",
+  "release_year": 1936
+},
+{
+  "title": "Age of Adaline",
+  "release_year": 2015
+},
+{
+  "title": "Alcatraz",
+  "release_year": 2012
+},
+{
+  "title": "Alexander's Ragtime Band",
+  "release_year": 1938
+},
+{
+  "title": "All About Eve",
+  "release_year": 1950
+},
+{
+  "title": "American Graffiti",
+  "release_year": 1973
+},
+{
+  "title": "American Yearbook",
+  "release_year": 2004
+},
+{
+  "title": "Americana",
+  "release_year": 2015
+},
+{
+  "title": "Another 48 Hours",
+  "release_year": 1990
+},
+{
+  "title": "Ant-Man",
+  "release_year": 2015
+},
+{
+  "title": "Around the Fire",
+  "release_year": 1998
+},
+{
+  "title": "Attack of the Killer Tomatoes",
+  "release_year": 1978
+},
+{
+  "title": "Babies",
+  "release_year": 2010
+},
+{
+  "title": "Barbary Coast",
+  "release_year": 1935
+},
+{
+  "title": "Basic Instinct",
+  "release_year": 1992
+},
+{
+  "title": "Beaches",
+  "release_year": 1988
+},
+{
+  "title": "Bedazzled",
+  "release_year": 2000
+},
+{
+  "title": "Bee Season",
+  "release_year": 2005
+},
+{
+  "title": "Bicentennial Man",
+  "release_year": 1999
+},
+{
+  "title": "Big Eyes",
+  "release_year": 2014
+},
+{
+  "title": "Big Sur",
+  "release_year": 2013
+},
+{
+  "title": "Big Touble in Little China",
+  "release_year": 1986
+},
+{
+  "title": "Birdman of Alcatraz",
+  "release_year": 1962
+},
+{
+  "title": "Blue Jasmine",
+  "release_year": 2013
+},
+{
+  "title": "Boys and Girls",
+  "release_year": 2000
+},
+{
+  "title": "Broken-A Modern Love Story",
+  "release_year": 2010
+},
+{
+  "title": "Bullitt",
+  "release_year": 1968
+},
+{
+  "title": "Burglar",
+  "release_year": 1987
+},
+{
+  "title": "By Hook or By Crook",
+  "release_year": 2001
+},
+{
+  "title": "Can't Stop the Music",
+  "release_year": 1980
+},
+{
+  "title": "Cardinal X",
+  "release_year": 2015
+},
+{
+  "title": "Casualties of War",
+  "release_year": 1989
+},
+{
+  "title": "Chan is Missing",
+  "release_year": 1982
+},
+{
+  "title": "Cherish",
+  "release_year": 2002
+},
+{
+  "title": "Chu Chu and the Philly Flash",
+  "release_year": 1981
+},
+{
+  "title": "City of Angels",
+  "release_year": 1998
+},
+{
+  "title": "Class Action",
+  "release_year": 1991
+},
+{
+  "title": "Common Threads: Stories From the Quilt",
+  "release_year": 1989
+},
+{
+  "title": "Confessions of a Burning Man",
+  "release_year": 2003
+},
+{
+  "title": "Copycat",
+  "release_year": 1995
+},
+{
+  "title": "Crackers",
+  "release_year": 1984
+},
+{
+  "title": "CSI: NY- episode 903",
+  "release_year": 2012
+},
+{
+  "title": "D.O.A",
+  "release_year": 1950
+},
+{
+  "title": "Dark Passage",
+  "release_year": 1947
+},
+{
+  "title": "Dawn of the Planet of the Apes",
+  "release_year": 2014
+},
+{
+  "title": "Days of Wine and Roses",
+  "release_year": 1962
+},
+{
+  "title": "Desperate Measures",
+  "release_year": 1998
+},
+{
+  "title": "Dim Sum: A Little Bit of Heart",
+  "release_year": 1985
+},
+{
+  "title": "Dirty Harry",
+  "release_year": 1971
+},
+{
+  "title": "Doctor Dolittle",
+  "release_year": 1998
+},
+{
+  "title": "Dopamine",
+  "release_year": 2003
+},
+{
+  "title": "Down Periscope",
+  "release_year": 1996
+},
+{
+  "title": "Dr. Dolittle 2",
+  "release_year": 2001
+},
+{
+  "title": "Dream for an Insomniac",
+  "release_year": 1996
+},
+{
+  "title": "Dream with the Fishes",
+  "release_year": 1997
+},
+{
+  "title": "Dying Young",
+  "release_year": 1991
+},
+{
+  "title": "Edtv",
+  "release_year": 1999
+},
+{
+  "title": "Escape From Alcatraz",
+  "release_year": 1979
+},
+{
+  "title": "Experiment in Terror",
+  "release_year": 1962
+},
+{
+  "title": "Faces of Death",
+  "release_year": 1978
+},
+{
+  "title": "Family Plot",
+  "release_year": 1976
+},
+{
+  "title": "Fandom",
+  "release_year": 2004
+},
+{
+  "title": "Fat Man and Little Boy",
+  "release_year": 1989
+},
+{
+  "title": "Fathers' Day",
+  "release_year": 1997
+},
+{
+  "title": "Fearless",
+  "release_year": 1993
+},
+{
+  "title": "Final Analysis",
+  "release_year": 1992
+},
+{
+  "title": "Flower Drum Song",
+  "release_year": 1961
+},
+{
+  "title": "Flubber",
+  "release_year": 1997
+},
+{
+  "title": "Forrest Gump",
+  "release_year": 1994
+},
+{
+  "title": "Foul Play",
+  "release_year": 1978
+},
+{
+  "title": "Freebie and the Bean",
+  "release_year": 1974
+},
+{
+  "title": "Gentleman Jim",
+  "release_year": 1942
+},
+{
+  "title": "George of the Jungle",
+  "release_year": 1997
+},
+{
+  "title": "Getting Even with Dad",
+  "release_year": 1994
+},
+{
+  "title": "God is a Communist?* (show me heart universe)",
+  "release_year": 2010
+},
+{
+  "title": "Godzilla",
+  "release_year": 2014
+},
+{
+  "title": "Golden Gate",
+  "release_year": 1994
+},
+{
+  "title": "Golden Gate",
+  "release_year": 1994
+},
+{
+  "title": "Greed",
+  "release_year": 1924
+},
+{
+  "title": "Groove",
+  "release_year": 2000
+},
+{
+  "title": "Guess Who's Coming to Dinner",
+  "release_year": 1967
+},
+{
+  "title": "Haiku Tunnel",
+  "release_year": 2001
+},
+{
+  "title": "Happy Gilmore",
+  "release_year": 1996
+},
+{
+  "title": "Hard to Hold",
+  "release_year": 1984
+},
+{
+  "title": "Harold and Maude",
+  "release_year": 1971
+},
+{
+  "title": "Heart and Souls",
+  "release_year": 1993
+},
+{
+  "title": "Heart Beat",
+  "release_year": 1980
+},
+{
+  "title": "Hello Frisco, Hello",
+  "release_year": 1943
+},
+{
+  "title": "Hemingway & Gelhorn",
+  "release_year": 2011
+},
+{
+  "title": "Herbie Rides Again",
+  "release_year": 1974
+},
+{
+  "title": "Hereafter",
+  "release_year": 2010
+},
+{
+  "title": "High Anxiety",
+  "release_year": 1977
+},
+{
+  "title": "High Crimes",
+  "release_year": 2002
+},
+{
+  "title": "High Crimes",
+  "release_year": 2002
+},
+{
+  "title": "Homeward Bound II: Lost in San Francisco",
+  "release_year": 1996
+},
+{
+  "title": "House of Sand and Fog",
+  "release_year": 2003
+},
+{
+  "title": "How Stella Got Her Groove Back",
+  "release_year": 1998
+},
+{
+  "title": "Hulk",
+  "release_year": 2003
+},
+{
+  "title": "I Am Michael",
+  "release_year": 2015
+},
+{
+  "title": "I Remember Mama",
+  "release_year": 1948
+},
+{
+  "title": "I's",
+  "release_year": 2011
+},
+{
+  "title": "Indiana Jones and the Last Crusade",
+  "release_year": 1989
+},
+{
+  "title": "Innerspace",
+  "release_year": 1987
+},
+{
+  "title": "Interview With The Vampire",
+  "release_year": 1994
+},
+{
+  "title": "Invasion of the Body Snatchers",
+  "release_year": 1978
+},
+{
+  "title": "It Came From Beneath the Sea",
+  "release_year": 1955
+},
+{
+  "title": "Jack",
+  "release_year": 1996
+},
+{
+  "title": "Jade",
+  "release_year": 1995
+},
+{
+  "title": "Jagged Edge",
+  "release_year": 1985
+},
+{
+  "title": "James and the Giant Peach",
+  "release_year": 1996
+},
+{
+  "title": "Joy Luck Club",
+  "release_year": 1993
+},
+{
+  "title": "Julie and Jack",
+  "release_year": 2003
+},
+{
+  "title": "Junior",
+  "release_year": 1994
+},
+{
+  "title": "Just Like Heaven",
+  "release_year": 2005
+},
+{
+  "title": "Just One Night",
+  "release_year": 2000
+},
+{
+  "title": "Kamikaze Hearts",
+  "release_year": 1986
+},
+{
+  "title": "Knife Fight",
+  "release_year": 2013
+},
+{
+  "title": "Live Nude Girls Unite",
+  "release_year": 2000
+},
+{
+  "title": "Looking",
+  "release_year": 2014
+},
+{
+  "title": "Love & Taxes",
+  "release_year": 2014
+},
+{
+  "title": "Magnum Force",
+  "release_year": 1973
+},
+{
+  "title": "Marnie",
+  "release_year": 1964
+},
+{
+  "title": "Maxie",
+  "release_year": 1985
+},
+{
+  "title": "Memoirs of an Invisible Man",
+  "release_year": 1992
+},
+{
+  "title": "Metro",
+  "release_year": 1997
+},
+{
+  "title": "Midnight Lace",
+  "release_year": 1960
+},
+{
+  "title": "Milk",
+  "release_year": 2008
+},
+{
+  "title": "Mission (aka City of Bars)",
+  "release_year": 2001
+},
+{
+  "title": "Mona Lisa Smile",
+  "release_year": 2003
+},
+{
+  "title": "Mother",
+  "release_year": 1996
+},
+{
+  "title": "Mrs. Doubtfire",
+  "release_year": 1993
+},
+{
+  "title": "Murder in the First",
+  "release_year": 2014
+},
+{
+  "title": "Murder in the First",
+  "release_year": 1995
+},
+{
+  "title": "My Reality",
+  "release_year": 2011
+},
+{
+  "title": "Need For Speed",
+  "release_year": 2014
+},
+{
+  "title": "Never Die Twice",
+  "release_year": 2001
+},
+{
+  "title": "Night of Henna",
+  "release_year": 2005
+},
+{
+  "title": "Nina Takes a Lover",
+  "release_year": 1994
+},
+{
+  "title": "Nine Months",
+  "release_year": 1995
+},
+{
+  "title": "Nine to Five",
+  "release_year": 1980
+},
+{
+  "title": "Nora Prentiss",
+  "release_year": 1947
+},
+{
+  "title": "On the Beach",
+  "release_year": 1959
+},
+{
+  "title": "On the Road",
+  "release_year": 2012
+},
+{
+  "title": "Pacific Heights",
+  "release_year": 1990
+},
+{
+  "title": "Pal Joey",
+  "release_year": 1957
+},
+{
+  "title": "Panther",
+  "release_year": 1995
+},
+{
+  "title": "Parks and Recreation",
+  "release_year": 2014
+},
+{
+  "title": "Patch Adams",
+  "release_year": 1998
+},
+{
+  "title": "Patty Hearst",
+  "release_year": 1988
+},
+{
+  "title": "Petulia",
+  "release_year": 1968
+},
+{
+  "title": "Phenomenon",
+  "release_year": 1996
+},
+{
+  "title": "Play it Again, Sam",
+  "release_year": 1972
+},
+{
+  "title": "Playing Mona Lisa",
+  "release_year": 2000
+},
+{
+  "title": "Pleasure of His Company",
+  "release_year": 1961
+},
+{
+  "title": "Point Blank",
+  "release_year": 1967
+},
+{
+  "title": "Pretty Woman",
+  "release_year": 1990
+},
+{
+  "title": "Psych-Out",
+  "release_year": 1968
+},
+{
+  "title": "Quicksilver",
+  "release_year": 1986
+},
+{
+  "title": "Quitters",
+  "release_year": 2015
+},
+{
+  "title": "Raising Cain",
+  "release_year": 1992
+},
+{
+  "title": "Red Diaper Baby",
+  "release_year": 2004
+},
+{
+  "title": "Red Widow",
+  "release_year": 2013
+},
+{
+  "title": "Rent",
+  "release_year": 2005
+},
+{
+  "title": "Rollerball",
+  "release_year": 2002
+},
+{
+  "title": "Romeo Must Die",
+  "release_year": 2000
+},
+{
+  "title": "San Andreas",
+  "release_year": 2015
+},
+{
+  "title": "San Francisco",
+  "release_year": 1936
+},
+{
+  "title": "Sausalito",
+  "release_year": 2000
+},
+{
+  "title": "Sense8",
+  "release_year": 2015
+},
+{
+  "title": "Serendipity",
+  "release_year": 2001
+},
+{
+  "title": "Serial",
+  "release_year": 1980
+},
+{
+  "title": "Seven Girlfriends",
+  "release_year": 1999
+},
+{
+  "title": "Shadow of the Thin Man",
+  "release_year": 1941
+},
+{
+  "title": "Shattered",
+  "release_year": 1991
+},
+{
+  "title": "Shoot the Moon",
+  "release_year": 1982
+},
+{
+  "title": "Sister Act",
+  "release_year": 1992
+},
+{
+  "title": "Sister Act 2: Back in the Habit",
+  "release_year": 1993
+},
+{
+  "title": "Smile Again, Jenny Lee",
+  "release_year": 2015
+},
+{
+  "title": "Sneakers",
+  "release_year": 1992
+},
+{
+  "title": "So I Married an Axe Murderer",
+  "release_year": 1993
+},
+{
+  "title": "Sphere",
+  "release_year": 1998
+},
+{
+  "title": "Star Trek II : The Wrath of Khan",
+  "release_year": 1982
+},
+{
+  "title": "Star Trek IV: The Voyage Home",
+  "release_year": 1986
+},
+{
+  "title": "Star Trek VI: The Undiscovered Country",
+  "release_year": 1991
+},
+{
+  "title": "Steve Jobs",
+  "release_year": 2015
+},
+{
+  "title": "Stigmata",
+  "release_year": 1999
+},
+{
+  "title": "Street Music",
+  "release_year": 1981
+},
+{
+  "title": "Sudden Fear",
+  "release_year": 1952
+},
+{
+  "title": "Sudden Impact",
+  "release_year": 1983
+},
+{
+  "title": "Summertime",
+  "release_year": 2015
+},
+{
+  "title": "Superman",
+  "release_year": 1978
+},
+{
+  "title": "Susan Slade",
+  "release_year": 1961
+},
+{
+  "title": "Sweet November",
+  "release_year": 2001
+},
+{
+  "title": "Swing",
+  "release_year": 2003
+},
+{
+  "title": "Swingin' Along",
+  "release_year": 1961
+},
+{
+  "title": "Take the Money and Run",
+  "release_year": 1969
+},
+{
+  "title": "Terminator - Genisys",
+  "release_year": 2015
+},
+{
+  "title": "The Assassination of Richard Nixon",
+  "release_year": 2004
+},
+{
+  "title": "The Bachelor",
+  "release_year": 1999
+},
+{
+  "title": "The Birds",
+  "release_year": 1963
+},
+{
+  "title": "The Bridge",
+  "release_year": 2006
+},
+{
+  "title": "The Caine Mutiny",
+  "release_year": 1954
+},
+{
+  "title": "The Californians",
+  "release_year": 2005
+},
+{
+  "title": "The Candidate",
+  "release_year": 1972
+},
+{
+  "title": "The Competition",
+  "release_year": 1980
+},
+{
+  "title": "The Conversation",
+  "release_year": 1974
+},
+{
+  "title": "The Core",
+  "release_year": 2003
+},
+{
+  "title": "The Dead Pool",
+  "release_year": 1988
+},
+{
+  "title": "The Diary of a Teenage Girl",
+  "release_year": 2015
+},
+{
+  "title": "The Doctor",
+  "release_year": 1991
+},
+{
+  "title": "The Doors",
+  "release_year": 1991
+},
+{
+  "title": "The Enforcer",
+  "release_year": 1976
+},
+{
+  "title": "The Fan",
+  "release_year": 1996
+},
+{
+  "title": "The Fog of War",
+  "release_year": 2003
+},
+{
+  "title": "The Game",
+  "release_year": 1997
+},
+{
+  "title": "The Graduate",
+  "release_year": 1967
+},
+{
+  "title": "The House on Telegraph Hill",
+  "release_year": 1951
+},
+{
+  "title": "The Internship",
+  "release_year": 2013
+},
+{
+  "title": "The Jazz Singer",
+  "release_year": 1927
+},
+{
+  "title": "The Lady from Shanghai",
+  "release_year": 1947
+},
+{
+  "title": "The Last of the Gladiators",
+  "release_year": 1988
+},
+{
+  "title": "The Laughing Policeman",
+  "release_year": 1973
+},
+{
+  "title": "The Lineup",
+  "release_year": 1958
+},
+{
+  "title": "The Love Bug",
+  "release_year": 1968
+},
+{
+  "title": "The Maltese Falcon",
+  "release_year": 1941
+},
+{
+  "title": "The Master",
+  "release_year": 2012
+},
+{
+  "title": "The Matrix",
+  "release_year": 1999
+},
+{
+  "title": "The Net",
+  "release_year": 1995
+},
+{
+  "title": "The Nightmare Before Christmas",
+  "release_year": 1993
+},
+{
+  "title": "The Organization",
+  "release_year": 1971
+},
+{
+  "title": "The Other Sister",
+  "release_year": 1999
+},
+{
+  "title": "The Parent Trap",
+  "release_year": 1998
+},
+{
+  "title": "The Presidio",
+  "release_year": 1988
+},
+{
+  "title": "The Princess Diaries",
+  "release_year": 2001
+},
+{
+  "title": "The Pursuit of Happyness",
+  "release_year": 2006
+},
+{
+  "title": "The Right Stuff",
+  "release_year": 1983
+},
+{
+  "title": "The Rock",
+  "release_year": 1996
+},
+{
+  "title": "The Sweetest Thing",
+  "release_year": 2002
+},
+{
+  "title": "The Ten Commandments",
+  "release_year": 1923
+},
+{
+  "title": "The Times of Harvey Milk",
+  "release_year": 1984
+},
+{
+  "title": "The Towering Inferno",
+  "release_year": 1974
+},
+{
+  "title": "The Wedding Planner",
+  "release_year": 2001
+},
+{
+  "title": "The Woman In Red",
+  "release_year": 1984
+},
+{
+  "title": "The Zodiac",
+  "release_year": 2005
+},
+{
+  "title": "They Call Me MISTER Tibbs",
+  "release_year": 1970
+},
+{
+  "title": "Thief of Hearts",
+  "release_year": 1984
+},
+{
+  "title": "Time After Time",
+  "release_year": 1979
+},
+{
+  "title": "Tin Cup",
+  "release_year": 1996
+},
+{
+  "title": "To the Ends of the Earth",
+  "release_year": 1948
+},
+{
+  "title": "True Believer",
+  "release_year": 1989
+},
+{
+  "title": "Tucker: The Man and His Dream",
+  "release_year": 1988
+},
+{
+  "title": "Tweek City",
+  "release_year": 2005
+},
+{
+  "title": "Twisted",
+  "release_year": 2004
+},
+{
+  "title": "Under the Tuscan Sun",
+  "release_year": 2003
+},
+{
+  "title": "Until the End of the World",
+  "release_year": 1991
+},
+{
+  "title": "Vegas in Space",
+  "release_year": 1992
+},
+{
+  "title": "Vertigo",
+  "release_year": 1958
+},
+{
+  "title": "What Dreams May Come",
+  "release_year": 1998
+},
+{
+  "title": "What the Bleep Do We Know",
+  "release_year": 2004
+},
+{
+  "title": "What's Up Doc?",
+  "release_year": 1972
+},
+{
+  "title": "When a Man Loves a Woman",
+  "release_year": 1994
+},
+{
+  "title": "Woman on the Run",
+  "release_year": 1950
+},
+{
+  "title": "Woman on Top",
+  "release_year": 2000
+},
+{
+  "title": "Yours, Mine and Ours",
+  "release_year": 1968
+},
+{
+  "title": "Zodiac",
+  "release_year": 2007
+}]

--- a/db/seeds/index.js
+++ b/db/seeds/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Movies = require('./data/movies')
+
+exports.seed = function (Knex) {
+  return Knex('movies').truncate()
+  .then(() => {
+    return Knex('movies').insert(Movies);
+  });
+};

--- a/lib/libraries/bookshelf.js
+++ b/lib/libraries/bookshelf.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const Bookshelf = require('bookshelf');
+
+const Knex = require('./knex');
+
+module.exports = Bookshelf(Knex);

--- a/lib/libraries/knex.js
+++ b/lib/libraries/knex.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const Knex = require('knex');
+
+const DatabaseConfig = require('../../db');
+
+module.exports = Knex(DatabaseConfig);

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Bookshelf = require('../libraries/bookshelf');
+
+module.exports = Bookshelf.Model.extend({
+  tableName: 'movies',
+  serialize: function () {
+    return {
+      id: this.get('id'),
+      title: this.get('title'),
+      release_year: this.get('release_year'),
+      object: 'movie'
+    };
+  }
+});

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,5 +11,13 @@ const server = new Hapi.Server({
 });
 
 server.connection({ port: Config.PORT });
+server.register([
+  require('hapi-bookshelf-serializer')
+], (err) => {
+  /* istanbul ignore if */
+  if (err) {
+    throw err;
+  }
+});
 
 module.exports = server;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -37,6 +37,11 @@
       "from": "anymatch@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
     },
+    "ap": {
+      "version": "0.2.0",
+      "from": "ap@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz"
+    },
     "argparse": {
       "version": "1.0.7",
       "from": "argparse@>=1.0.2 <2.0.0",
@@ -87,6 +92,11 @@
       "from": "async-each@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
     },
+    "babel-runtime": {
+      "version": "6.9.0",
+      "from": "babel-runtime@>=6.6.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.0.tgz"
+    },
     "balanced-match": {
       "version": "0.4.1",
       "from": "balanced-match@>=0.4.1 <0.5.0",
@@ -102,6 +112,23 @@
       "from": "bluebird@>=3.0.6 <4.0.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.0.tgz"
     },
+    "bookshelf": {
+      "version": "0.9.5",
+      "from": "bookshelf@*",
+      "resolved": "https://registry.npmjs.org/bookshelf/-/bookshelf-0.9.5.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.10.2",
+          "from": "bluebird@>=2.9.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+        }
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "from": "boom@>=2.8.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+    },
     "brace-expansion": {
       "version": "1.1.4",
       "from": "brace-expansion@>=1.0.0 <2.0.0",
@@ -111,6 +138,11 @@
       "version": "1.8.5",
       "from": "braces@>=1.8.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+    },
+    "buffer-writer": {
+      "version": "1.0.1",
+      "from": "buffer-writer@1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz"
     },
     "camelcase": {
       "version": "1.2.1",
@@ -184,10 +216,20 @@
       "from": "configstore@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz"
     },
+    "core-js": {
+      "version": "2.4.0",
+      "from": "core-js@>=2.4.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
+    },
     "core-util-is": {
       "version": "1.0.2",
       "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "create-error": {
+      "version": "0.3.1",
+      "from": "create-error@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/create-error/-/create-error-0.3.1.tgz"
     },
     "d": {
       "version": "0.1.1",
@@ -252,6 +294,11 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
+    },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "from": "double-ended-queue@>=2.1.0-0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
     },
     "duplexer": {
       "version": "0.1.1",
@@ -421,6 +468,11 @@
       "from": "expand-range@>=1.8.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
     },
+    "extend": {
+      "version": "2.0.1",
+      "from": "extend@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+    },
     "extglob": {
       "version": "0.3.2",
       "from": "extglob@>=0.3.1 <0.4.0",
@@ -462,6 +514,16 @@
       "version": "2.2.3",
       "from": "fill-range@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+    },
+    "findup-sync": {
+      "version": "0.3.0",
+      "from": "findup-sync@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
+    },
+    "flagged-respawn": {
+      "version": "0.3.2",
+      "from": "flagged-respawn@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz"
     },
     "flat-cache": {
       "version": "1.0.10",
@@ -1125,6 +1187,11 @@
       "from": "generate-object-property@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
+    "generic-pool": {
+      "version": "2.1.1",
+      "from": "generic-pool@2.1.1",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
+    },
     "github-url-from-git": {
       "version": "1.4.0",
       "from": "github-url-from-git@>=1.4.0 <2.0.0",
@@ -1351,6 +1418,17 @@
         }
       }
     },
+    "hapi-bookshelf-serializer": {
+      "version": "2.1.0",
+      "from": "hapi-bookshelf-serializer@*",
+      "resolved": "https://registry.npmjs.org/hapi-bookshelf-serializer/-/hapi-bookshelf-serializer-2.1.0.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.10.2",
+          "from": "bluebird@>=2.9.34 <3.0.0"
+        }
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "from": "has-ansi@>=2.0.0 <3.0.0",
@@ -1360,6 +1438,16 @@
       "version": "1.0.0",
       "from": "has-flag@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+    },
+    "hashmap": {
+      "version": "2.0.6",
+      "from": "hashmap@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hashmap/-/hashmap-2.0.6.tgz"
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "from": "hoek@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "ignore-by-default": {
       "version": "1.0.1",
@@ -1375,6 +1463,11 @@
       "version": "2.0.3",
       "from": "infinity-agent@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+    },
+    "inflection": {
+      "version": "1.10.0",
+      "from": "inflection@>=1.5.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz"
     },
     "inflight": {
       "version": "1.0.5",
@@ -1395,6 +1488,11 @@
       "version": "0.11.4",
       "from": "inquirer@>=0.11.0 <0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz"
+    },
+    "interpret": {
+      "version": "0.6.6",
+      "from": "interpret@>=0.6.5 <0.7.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -1586,6 +1684,33 @@
       "from": "kind-of@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.3.tgz"
     },
+    "knex": {
+      "version": "0.11.5",
+      "from": "knex@*",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.11.5.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@>=4.6.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
+        },
+        "minimist": {
+          "version": "1.1.3",
+          "from": "minimist@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.12 <2.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        }
+      }
+    },
     "latest-version": {
       "version": "1.0.1",
       "from": "latest-version@>=1.0.0 <2.0.0",
@@ -1600,6 +1725,11 @@
       "version": "0.2.5",
       "from": "levn@>=0.2.5 <0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+    },
+    "liftoff": {
+      "version": "2.2.1",
+      "from": "liftoff@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.1.tgz"
     },
     "lodash": {
       "version": "3.10.1",
@@ -1923,6 +2053,11 @@
       "from": "package-json@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz"
     },
+    "packet-reader": {
+      "version": "0.2.0",
+      "from": "packet-reader@0.2.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz"
+    },
     "parse-glob": {
       "version": "3.0.4",
       "from": "parse-glob@>=3.0.4 <4.0.0",
@@ -1943,6 +2078,33 @@
       "from": "pause-stream@0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
     },
+    "pg": {
+      "version": "4.5.5",
+      "from": "pg@*",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-4.5.5.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "4.3.6",
+          "from": "semver@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "from": "pg-connection-string@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
+    },
+    "pg-types": {
+      "version": "1.11.0",
+      "from": "pg-types@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.11.0.tgz"
+    },
+    "pgpass": {
+      "version": "0.0.3",
+      "from": "pgpass@0.0.3",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz"
+    },
     "pify": {
       "version": "2.3.0",
       "from": "pify@>=2.0.0 <3.0.0",
@@ -1957,6 +2119,31 @@
       "version": "2.0.1",
       "from": "pinkie-promise@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+    },
+    "pool2": {
+      "version": "1.3.4",
+      "from": "pool2@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pool2/-/pool2-1.3.4.tgz"
+    },
+    "postgres-array": {
+      "version": "1.0.0",
+      "from": "postgres-array@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.0.tgz"
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "from": "postgres-bytea@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz"
+    },
+    "postgres-date": {
+      "version": "1.0.2",
+      "from": "postgres-date@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.2.tgz"
+    },
+    "postgres-interval": {
+      "version": "1.0.2",
+      "from": "postgres-interval@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.2.tgz"
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -2031,6 +2218,11 @@
       "version": "1.0.1",
       "from": "readline2@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "from": "rechoir@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
     },
     "regex-cache": {
       "version": "0.4.3",
@@ -2114,6 +2306,11 @@
       "from": "sigmund@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
+    "simple-backoff": {
+      "version": "1.0.0",
+      "from": "simple-backoff@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-backoff/-/simple-backoff-1.0.0.tgz"
+    },
     "slide": {
       "version": "1.1.6",
       "from": "slide@>=1.1.5 <2.0.0",
@@ -2178,6 +2375,18 @@
       "version": "2.3.8",
       "from": "through@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+    },
+    "tildify": {
+      "version": "1.0.0",
+      "from": "tildify@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
+      "dependencies": {
+        "user-home": {
+          "version": "1.1.1",
+          "from": "user-home@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+        }
+      }
     },
     "timed-out": {
       "version": "2.0.0",
@@ -2267,6 +2476,17 @@
       "version": "2.0.2",
       "from": "uuid@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz"
+    },
+    "v8flags": {
+      "version": "2.0.11",
+      "from": "v8flags@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
+      "dependencies": {
+        "user-home": {
+          "version": "1.1.1",
+          "from": "user-home@>=1.1.1 <2.0.0"
+        }
+      }
     },
     "which": {
       "version": "1.2.9",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "A RESTful API for movies filmedd in San Francisco",
   "main": "lib/index.js",
   "scripts": {
+    "db:migrate": "knex migrate:latest --knexfile db/index.js",
+    "db:migrate:make": "knex migrate:make --knexfile db/index.js",
+    "db:reset": "dropdb sfmovies_development; createdb -O sfmovies_user sfmovies_development && npm run db:migrate",
+    "db:rollback": "knex migrate:rollback --knexfile db/index.js",
+    "db:seed": "npm run db:reset && knex seed:run --knexfile db/index.js",
     "enforce": "istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100",
     "lint": "eslint .",
     "release:patch": "changelog -p && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version patch && git push origin && git push origin --tags",
@@ -24,7 +29,11 @@
   },
   "homepage": "https://github.com/keenadams/sfmovies#readme",
   "dependencies": {
-    "hapi": "^13.4.1"
+    "bookshelf": "^0.9.5",
+    "hapi": "^13.4.1",
+    "hapi-bookshelf-serializer": "^2.1.0",
+    "knex": "^0.11.5",
+    "pg": "^4.5.5"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const Movie = require('../../lib/models/movie');
+
+describe('movie model', () => {
+
+  describe('serialize', () => {
+
+    it('includes all of the necessary fields', () => {
+      const movie = Movie.forge().serialize();
+
+      expect(movie).to.have.all.keys([
+        'id',
+        'title',
+        'release_year',
+        'object'
+      ]);
+    });
+
+  });
+
+});


### PR DESCRIPTION
What:  Setup the sfmovies_development db, defines a movie model, and then implements testing on that model.

Why: We need a database to store our movies in SF and a movie model for the movies table.

Details:
- Adds a connection to our postgres sfmovies_development in 'config/development.js'
- Adds the 'create_movie' migration under 'db/migrations'
- Adds seed data for the movie table
- Adds a test for our movie model
