### PR TITLE
chore(dbscripts): adds db setup scripts in package.json and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ node_js:
 env:
   - NODE_ENV="test"
 before_script:
-  - createuser sfmovies_user
-  - createdb -O sfmovies_user sfmovies_test
-  - npm run db:migrate
+  - npm run db:setup:user
+  - npm run db:reset
 script:
   - npm test
   - npm run enforce

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "db:migrate": "knex migrate:latest --knexfile db/index.js",
     "db:migrate:make": "knex migrate:make --knexfile db/index.js",
-    "db:reset": "dropdb sfmovies_development; createdb -O sfmovies_user sfmovies_development && npm run db:migrate",
+    "db:reset": "if [ \"$NODE_ENV\" != \"production\" ]; then dropdb $(node -p \"require('./config').DB_NAME\"); npm run db:setup && npm run db:migrate; fi",
     "db:rollback": "knex migrate:rollback --knexfile db/index.js",
     "db:seed": "npm run db:reset && knex seed:run --knexfile db/index.js",
+    "db:setup": "if [ \"$NODE_ENV\" != \"production\" ]; then createdb -O $(node -e \"var c = require('./config'); console.log(c.DB_USER, c.DB_NAME);\"); fi",
+    "db:setup:user": "if [ \"$NODE_ENV\" != \"production\" ]; then createuser $(node -p \"require('./config').DB_USER\"); fi",
     "enforce": "istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100",
     "lint": "eslint .",
     "release:patch": "changelog -p && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version patch && git push origin && git push origin --tags",


### PR DESCRIPTION
What: Adds `db:setup` and `db:setup:user` scripts

Why: We want to remove hardcoded lines from our .travis.yml file

Details:
- Add `db:setup` and `db:setup:user`scripts in package.json
- Uses `db:setup:user` in .travis.yml file instead of hardcoding the setup
