### PR TITLE
feat(movies-post): adds post endpoint for movies

### DIFF
--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Movie = require('../../../models/movie');
+
+exports.create = (payload) => {
+  return new Movie().save(payload)
+  .then((movie) => {
+    return new Movie({ id: movie.id }).fetch();
+  });
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Controller     = require('./controller.js');
+const MovieValidator = require('../../../validators/movie');
+
+exports.register = (server, options, next) => {
+
+  server.route([{
+    method: 'POST',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.create(request.payload));
+      },
+      validate: {
+        payload: MovieValidator
+      }
+    }
+  }]);
+
+  next();
+
+};
+
+exports.register.attributes = {
+  name: 'movies'
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,5 +11,18 @@ const server = new Hapi.Server({
 });
 
 server.connection({ port: Config.PORT });
+server.register([
+  require('hapi-bookshelf-serializer'),
+  {
+    register: require('hapi-format-error'),
+    options: { joiStatusCode: 422 }
+  },
+  require('./plugins/features/movies')
+], (err) => {
+  /* istanbul ignore if */
+  if (err) {
+    throw err;
+  }
+});
 
 module.exports = server;

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  title: Joi.string().min(1).max(255).required(),
+  release_year: Joi.number().integer().min(1878).max(9999).optional()
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "bookshelf": "^0.10.4",
     "hapi": "^16.5.2",
     "hapi-bookshelf-serializer": "^2.1.0",
+    "hapi-format-error": "^1.1.0",
+    "joi": "^10.6.0",
     "knex": "^0.13.0",
     "pg": "^7.1.2"
   },

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Controller = require('../../../../lib/plugins/features/movies/controller');
+const Movie      = require('../../../../lib/models/movie');
+
+describe('movie controller', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      const payload = { title: 'WALL-E' };
+
+      return Controller.create(payload)
+      .then((movie) => {
+        expect(movie.get('title')).to.eql(payload.title);
+
+        return new Movie({ id: movie.id }).fetch();
+      })
+      .then((movie) => {
+        expect(movie.get('title')).to.eql(payload.title);
+      });
+    });
+
+  });
+
+});

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Movies = require('../../../../lib/server');
+
+describe('movies integration', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'POST',
+        payload: { title: 'Volver' }
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result.object).to.eql('movie');
+      });
+    });
+
+  });
+
+});

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieValidator = require('../../lib/validators/movie');
+
+describe('movie validator', () => {
+
+  describe('title', () => {
+
+    it('is required', () => {
+      const payload = {};
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is less than 255 characters', () => {
+      const payload = { title: 'b'.repeat(256) };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('release_year', () => {
+
+    it('is after 1878', () => {
+      const payload = {
+        title: 'Test Movie',
+        release_year: 1776
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        title: 'Test Movie',
+        release_year: 8675309
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,6 +1008,10 @@ hapi-bookshelf-serializer@^2.1.0:
     bluebird "^2.9.34"
     boom "^2.8.0"
 
+hapi-format-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hapi-format-error/-/hapi-format-error-1.1.0.tgz#28d97f82b40f1b1d1b62b0215eab1cdfe983bbde"
+
 hapi@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/hapi/-/hapi-16.5.2.tgz#d1dadf33721c6ac3aaa905ce086d9c7ffb883092"


### PR DESCRIPTION
**What:** Adds a post endpoint for movies with validators.
**Why:** We want to be able to create movies!

**Details:**
- Adds validator for movies and accompanying tests
- Adds movie controller with `create` function
- Adds endpoint into the server
- Adds controller and integration tests